### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   lhci:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: quality-gates

--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   ui-gates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closed in favor of a replacement branch that follows AIGCCore's required `codex/fix/...` branch naming policy and includes the pnpm version alignment needed for the performance checks.