### PR TITLE
docs: remove personal security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Older tags may receive best-effort fixes only.
 
 Do not open public issues for suspected vulnerabilities.
 
-Report privately by emailing: `saagar210@gmail.com`
+Report privately through this repository's GitHub security advisory flow when enabled, or contact the repository owner through their GitHub profile.
 
 Include:
 


### PR DESCRIPTION
## What
- Replaces the personal vulnerability-reporting email in SECURITY.md with repository-owner/GitHub security reporting guidance.

## Why
- Reduces personal contact exposure before considering temporary public visibility.

## How
- Updates the security policy wording only.

## Testing
- gitleaks detect --no-banner --redact --source /Users/d/.codex/worktrees/aigccore-public-readiness --log-opts='--all'

## Performance Impact
- None; documentation only.

## Risk / Notes
- GitHub private vulnerability reporting should be enabled before relying on that flow for a public repo.