### PR TITLE
ci: harden workflow security alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: codeql
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "30 13 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: codeql-javascript-typescript
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@78ed0c7291d93e40c51b085850dc669a4c3ab73b
+        with:
+          languages: javascript-typescript
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@78ed0c7291d93e40c51b085850dc669a4c3ab73b

--- a/.github/workflows/codex-quality-security.yml
+++ b/.github/workflows/codex-quality-security.yml
@@ -7,22 +7,24 @@ on:
   schedule:
     - cron: "0 13 * * 1"
 
+permissions: read-all
+
 jobs:
   verify:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.29.2
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - name: Install dependencies
         run: |
           if [ -f package.json ]; then
@@ -42,29 +44,29 @@ jobs:
   secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
       - name: TruffleHog secret scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@0fa069c12f0c7baf431041cd1e564a9c5058846c
         with:
           extra_args: --results=verified
 
   sast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Semgrep
-        uses: returntocorp/semgrep-action@v1
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d
         with:
           config: p/default
 
   dependency_and_misconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Trivy FS scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           scan-type: fs
           scan-ref: .
@@ -83,14 +85,14 @@ jobs:
       actions: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.3.1
+        uses: ossf/scorecard-action@e93faf2ab2f3663b51bc6e62d42b8520f2eff874
         with:
           publish_results: false
           results_file: scorecard-results.sarif
           results_format: sarif
       - name: Upload scorecard SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@78ed0c7291d93e40c51b085850dc669a4c3ab73b
         with:
           sarif_file: scorecard-results.sarif

--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main, master]
 
+permissions: read-all
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,13 +11,13 @@ jobs:
   lhci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.29.2
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions: read-all
+
 jobs:
   enforce:
     runs-on: ubuntu-latest

--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main, master]
 
+permissions: read-all
+
 jobs:
   perf-bundle:
     if: ${{ vars.PERF_PROFILE == 'production' }}

--- a/.github/workflows/perf-foundation.yml
+++ b/.github/workflows/perf-foundation.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main, master]
 
+permissions: read-all
+
 jobs:
   perf-bundle:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -13,7 +13,7 @@ jobs:
     name: quality-gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -26,11 +26,11 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.29.2
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 22
           cache: pnpm
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: test-artifacts
           path: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -11,6 +11,8 @@ on:
     tags:
       - "v*"
 
+permissions: read-all
+
 jobs:
   build_signed_artifacts:
     strategy:
@@ -22,7 +24,7 @@ jobs:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -40,18 +42,18 @@ jobs:
             patchelf
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.29.2
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -150,7 +152,7 @@ jobs:
             Out-File -Encoding utf8 $checksumPath
 
       - name: Upload release bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-${{ matrix.os }}-${{ env.EXPECTED_VERSION }}
           path: ${{ env.BUNDLE_DIR }}

--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -11,13 +11,13 @@ jobs:
   ui-gates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10.29.2
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## What
- Add CodeQL analysis for the JavaScript and TypeScript surface.
- Set read-only default workflow permissions where Scorecard reported missing top-level permissions.
- Pin unpinned workflow actions to commit hashes for the alert-targeted workflows.

## Why
- Reduce open code scanning alerts from OpenSSF Scorecard for SAST, workflow token permissions, and action pinning.

## How
- Keep write permissions scoped to the jobs that need SARIF upload.
- Resolve action tags and branches to full commit SHAs.

## Testing
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest` passed.
- Ruby YAML parse over `.github/workflows/*.yml` passed.
- `node scripts/ci/require-tests-and-docs.mjs` passed.
- `cargo test --workspace` passed.
- `bash .codex/scripts/run_verify_commands.sh` not fully run: stopped at `pnpm lint` because `node_modules` is missing, and local package install is blocked in this session.

## Performance impact
- None expected for runtime; CI adds a CodeQL workflow.

## Risk / Notes
- Scorecard alerts for branch protection, repo age, review history, OpenSSF badge, full fuzzing adoption, and Python package hash pinning remain outside this safe patch.

## Screenshots (UI only)
- N/A

## Lockfile rationale (if lockfile changed)
- N/A

## Baseline governance (if .perf-baselines changed)
- N/A