### PR TITLE
ci: restrict workflow token defaults

### DIFF
--- a/.github/workflows/codex-quality-security.yml
+++ b/.github/workflows/codex-quality-security.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "0 13 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   verify:

--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main, master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   commitlint:

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   enforce:

--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main, master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   perf-bundle:

--- a/.github/workflows/perf-foundation.yml
+++ b/.github/workflows/perf-foundation.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main, master]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   perf-bundle:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -11,7 +11,8 @@ on:
     tags:
       - "v*"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build_signed_artifacts:


### PR DESCRIPTION
## What

- Replaces broad workflow-level `read-all` token defaults with `contents: read` across the Scorecard-flagged workflows.

## Why

- OpenSSF Scorecard reports high-priority token-permission findings on these workflows.
- Narrow defaults reduce the blast radius of the default GitHub token while preserving existing job-level permissions where a job needs more.

## How

- Keeps existing job-level explicit permissions intact.
- Changes only workflow-level defaults in CI/release workflow files.

## Testing

- Commands run:
  - `python3` workflow YAML parse over `.github/workflows/*.yml`
  - `git diff --cached --check`
- Results: passed.
- Not run: full `.codex/scripts/run_verify_commands.sh` because this fresh clone has no `node_modules`, and local policy blocked `pnpm install`.

## Performance impact

- Bundle delta: none expected.
- Build time delta: none expected.
- Lighthouse delta: not run; no UI/runtime change.
- API latency delta: none expected.
- DB query delta: none expected.

## Risk / Notes

- Release and Scorecard jobs keep their explicit job-level permissions.
- Existing PR-template case-collision drift in the local checkout was not included in this PR.

## Screenshots (UI only)

- N/A.

## Lockfile rationale (if lockfile changed)

- N/A.