### PR TITLE
docs: add private advisory report link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,9 @@ Older tags may receive best-effort fixes only.
 
 Do not open public issues for suspected vulnerabilities.
 
-Use this repository's private vulnerability reporting flow to report suspected vulnerabilities. On GitHub, open the repository's **Security** tab and choose **Report a vulnerability**.
+Use this repository's private vulnerability reporting flow to report suspected vulnerabilities:
+
+- GitHub private report form: https://github.com/saagpatel/AIGCCore/security/advisories/new
 
 Include:
 


### PR DESCRIPTION
## What
- Adds the direct GitHub private advisory reporting URL to SECURITY.md.

## Why
- OpenSSF Scorecard still reports the security policy as missing linked private-reporting content even after private vulnerability reporting was enabled.

## How
- Documentation-only policy link update.

## Testing
- Not run (documentation-only change).

## Performance Impact
- None expected.

## Risk / Notes
- Low risk; policy text only.
