### PR TITLE
ci: exempt dependency bot branches from human gates

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   branch-name:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   enforce:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- skip commitlint and branch-name checks for Dependabot/Renovate branches
- skip lockfile-rationale enforcement for Dependabot/Renovate branches

## Why
Dependabot PRs cannot satisfy human branch naming, commit message, or manual lockfile rationale requirements. These metadata gates were blocking dependency update PRs before substantive checks could matter.

## Verification
- pnpm git:guard:branch
- pnpm git:guard:atomic
- pnpm git:guard:generated
- pnpm git:guard:large-files
- pnpm git:guard:secrets

## Follow-up
AIGCCore still has pnpm overrides in package.json; pnpm reports those are ignored. After the active security bump PR reruns, migrate those overrides into pnpm-workspace.yaml if alerts remain.