### PR TITLE
docs: align AGENTS path inheritance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,23 @@
 # AGENTS.md (Repo Root) — AIGC Core
 
 <!-- comm-contract:start -->
+
 ## Communication Contract (Global)
-- Follow `/Users/d/.codex/policies/communication/BigPictureReportingV1.md` for all user-facing updates.
-- Use exact section labels from `BigPictureReportingV1.md` for formal delivery, blocker, waiting, risk, decision, or explicit status/report requests.
-- Keep ordinary in-flight updates conversational, warm, PM-readable, operator-grade, and low-noise.
-- Keep technical details in internal artifacts unless explicitly requested by the user or required by failure, risk, or verification.
+
+- Inherit global Codex communication and reporting rules from `/Users/d/.codex/AGENTS.override.md` and `/Users/d/.codex/policies/communication/BigPictureReportingV1.md`.
+- Repo-specific instructions below add project constraints only; do not restate global voice or status-reporting rules here.
 - Honor toggles literally: `simple mode`, `show receipts`, `tech mode`, `debug mode`.
 <!-- comm-contract:end -->
-  This file defines canonical project commands, paths, and repo-specific conventions for this workspace.
+
+This file defines canonical project commands, paths, and repo-specific conventions for this workspace.
 
 ## Canonical Paths
 
-- Rust domain core: `/Users/d/Projects/AIGCCore/core`
-- Tauri shell + command handlers: `/Users/d/Projects/AIGCCore/src-tauri`
-- React UI: `/Users/d/Projects/AIGCCore/src`
-- Local validator CLI(s): `/Users/d/Projects/AIGCCore/tools`
-- Packet-driven docs created in-repo: `/Users/d/Projects/AIGCCore/docs`
+- Rust domain core: `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/core`
+- Tauri shell + command handlers: `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/src-tauri`
+- React UI: `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/src`
+- Local validator CLI(s): `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/tools`
+- Packet-driven docs created in-repo: `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/docs`
 
 ## Canonical Commands
 
@@ -28,7 +29,7 @@ Primary runner is `pnpm` and Rust `cargo`.
 - Run all eval gates locally: `pnpm gate:all`
 - Rust tests: `cargo test --workspace`
 
-Source of truth for scripts is `/Users/d/Projects/AIGCCore/package.json`.
+Source of truth for scripts is `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore/package.json`.
 
 ## Hard Rules (Packet-Aligned)
 


### PR DESCRIPTION
<!-- codex-os-managed -->

## What

- Aligns `AGENTS.md` with the global Codex communication/reporting inheritance model.
- Updates canonical local paths to the repo's actual location under `/Users/d/Projects/MoneyPRJsViaGPT/AIGCCore`.

## Why

- The repo was surfacing as active-infra dirty state because this local guidance fix was left unlanded.
- The previous file restated global reporting rules and pointed at an outdated repo path, which can mislead future local agents.

## How

- Keep repo-specific constraints in `AGENTS.md`.
- Delegate global voice/reporting behavior to the global override and BigPictureReporting policy.
- Correct the path references for core, Tauri, React UI, tools, docs, and package scripts.

## Testing

- Commands run:
  - `git diff --stat -- AGENTS.md`
- Results:
  - One documentation file changed only.

## Performance impact

- Bundle delta: n/a
- Build time delta: n/a
- Lighthouse delta: n/a
- API latency delta: n/a
- DB query delta: n/a

## Risk / Notes

- Documentation-only repo guidance change.
- Branch was created from current `origin/main` to avoid dragging stale local branch history into the PR.

## Screenshots (UI only)

- n/a

## Lockfile rationale (if lockfile changed)

- n/a

## Baseline governance (if .perf-baselines changed)

- `perf-baseline-update` label applied: n/a
- Reviewer signoff: n/a
- Rollback note: revert the AGENTS.md documentation-only change if needed.
