### PR TITLE
fix: patch aigccore rand advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,9 +2592,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary
- update Cargo.lock to rand 0.9.3 to clear the open Dependabot advisory

## Verification
- cargo check --locked
- git diff --check -- Cargo.lock

## Notes
- Leaves the existing upstream glib advisory untouched for the separate glib lane.