### PR TITLE
fix: align AIGCCore crypto updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -35,9 +45,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -61,7 +71,7 @@ dependencies = [
  "csv",
  "hex",
  "idna",
- "rand",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -391,26 +401,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
- "aead",
+ "aead 0.6.1",
  "chacha20",
- "cipher",
+ "cipher 0.5.2",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -432,9 +442,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
- "zeroize",
+ "inout 0.1.4",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -561,7 +587,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.1",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -630,7 +658,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1228,6 +1265,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1718,6 +1756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2442,13 +2489,12 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2460,7 +2506,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -2591,12 +2637,23 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2626,6 +2683,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -3857,7 +3920,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -3928,6 +3991,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4916,12 +4989,6 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,11 +6,11 @@ license = "UNLICENSED"
 
 [dependencies]
 aes-gcm = "0.10.3"
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = "0.11.0"
 csv = "1.3.0"
 hex = "0.4.3"
 idna = "1.0.3"
-rand = "0.9.2"
+rand = "0.10.2"
 regex = "1.10"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.120"

--- a/core/src/determinism/zip.rs
+++ b/core/src/determinism/zip.rs
@@ -71,7 +71,8 @@ pub fn zip_dir_deterministic(root_dir: &Path, out_zip: &Path) -> CoreResult<Stri
         std::io::copy(&mut rf, &mut zw)?;
     }
 
-    zw.set_comment("");
+    zw.set_comment("")
+        .map_err(|e| CoreError::Zip(e.to_string()))?;
     zw.finish().map_err(|e| CoreError::Zip(e.to_string()))?;
 
     // Compute sha256 of zip bytes (used by export completed + validator outputs)

--- a/core/src/storage/crypto.rs
+++ b/core/src/storage/crypto.rs
@@ -1,7 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce as AesNonce};
-use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use rand::RngCore;
+use chacha20poly1305::{aead::Aead as XAead, KeyInit as XKeyInit, XChaCha20Poly1305, XNonce};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[allow(non_camel_case_types)]
@@ -35,8 +35,10 @@ pub fn encrypt_bytes(
                 .map_err(|e| CoreError::InvalidInput(format!("invalid key: {}", e)))?;
             let mut nonce = [0u8; 24];
             rand::rng().fill_bytes(&mut nonce);
+            let xnonce = XNonce::try_from(nonce.as_slice())
+                .map_err(|e| CoreError::InvalidInput(format!("invalid nonce: {}", e)))?;
             let ct = cipher
-                .encrypt(XNonce::from_slice(&nonce), plaintext)
+                .encrypt(&xnonce, plaintext)
                 .map_err(|e| CoreError::PolicyBlocked(format!("encryption failed: {}", e)))?;
             Ok(EncryptedBlob {
                 algorithm,
@@ -71,8 +73,10 @@ pub fn decrypt_bytes(blob: &EncryptedBlob, dek: &[u8; 32]) -> CoreResult<Vec<u8>
             }
             let cipher = XChaCha20Poly1305::new_from_slice(dek)
                 .map_err(|e| CoreError::InvalidInput(format!("invalid key: {}", e)))?;
+            let xnonce = XNonce::try_from(blob.nonce.as_slice())
+                .map_err(|e| CoreError::InvalidInput(format!("invalid nonce: {}", e)))?;
             cipher
-                .decrypt(XNonce::from_slice(&blob.nonce), blob.ciphertext.as_ref())
+                .decrypt(&xnonce, blob.ciphertext.as_ref())
                 .map_err(|e| CoreError::PolicyBlocked(format!("decryption failed: {}", e)))
         }
         EncryptionAlgorithm::AES_256_GCM => {

--- a/core/src/storage/key_management.rs
+++ b/core/src/storage/key_management.rs
@@ -1,5 +1,5 @@
 use crate::error::{CoreError, CoreResult};
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
 use std::process::Command;


### PR DESCRIPTION
## Summary
- carry the rand 0.10.2 update from Dependabot #51
- carry the chacha20poly1305 0.11.0 update from Dependabot #53
- update rand/chacha trait imports for the new APIs
- handle deterministic zip comment errors so strict Rust gates do not trip on the must-use result

## Verification
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings (blocked by existing repo-wide clippy baseline outside this dependency lane after dependency-specific fixes passed compile/test)
- pnpm install && bash .codex/scripts/run_verify_commands.sh (local policy blocked pnpm install; remote CI will verify full workflow)

Supersedes #51 and #53 after this replacement lands green.