### PR TITLE
fix: adapt random byte generation to rand 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "csv",
  "hex",
  "idna",
- "rand",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -401,13 +401,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1229,6 +1240,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2592,12 +2604,23 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2627,6 +2650,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -3859,7 +3888,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "web-time",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ chacha20poly1305 = "0.10.1"
 csv = "1.3.0"
 hex = "0.4.3"
 idna = "1.0.3"
-rand = "0.9.2"
+rand = "0.10.2"
 regex = "1.10"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.120"

--- a/core/src/storage/crypto.rs
+++ b/core/src/storage/crypto.rs
@@ -1,7 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce as AesNonce};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[allow(non_camel_case_types)]

--- a/core/src/storage/key_management.rs
+++ b/core/src/storage/key_management.rs
@@ -1,5 +1,5 @@
 use crate::error::{CoreError, CoreResult};
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
 use std::process::Command;


### PR DESCRIPTION
## Summary
- carries Dependabot's rand 0.10.2 bump from #51
- updates storage crypto/key-management imports from `RngCore` to the rand 0.10 `Rng` trait so existing `fill_bytes` calls compile

## Verification
- cargo test --manifest-path core/Cargo.toml --lib --no-run

Supersedes #51 once this PR is green and merged.